### PR TITLE
fix: persist gender toggle edits in settings grid

### DIFF
--- a/IslandCaller.Plugin2/Views/SettingPage.axaml
+++ b/IslandCaller.Plugin2/Views/SettingPage.axaml
@@ -83,7 +83,7 @@
                             <DataGridTemplateColumn Header="性别">
                                 <DataGridTemplateColumn.CellTemplate>
                                     <DataTemplate>
-                                        <ToggleButton IsChecked="{Binding Gender, Converter={StaticResource IntToBoolConverter}}"
+                                        <ToggleButton IsChecked="{Binding Gender, Mode=TwoWay, Converter={StaticResource IntToBoolConverter}}"
                                                       Content="{Binding Gender, Converter={StaticResource GenderConverter}}">
                                         </ToggleButton>
                                     </DataTemplate>


### PR DESCRIPTION
### Motivation
- The `ToggleButton` in the settings DataGrid used a one-way `IsChecked` binding, so clicking the gender toggle did not reliably update `StudentModel.Gender` and therefore changes were not persisted.

### Description
- Add `Mode=TwoWay` to the gender `ToggleButton` `IsChecked` binding in `IslandCaller.Plugin2/Views/SettingPage.axaml` so UI toggles write back to `StudentModel.Gender` and the existing property-change handlers will save the profile.

### Testing
- Verified the XAML change is present in the file and attempted to build with `dotnet`, but the SDK is not available in this environment (`bash: command not found: dotnet`), so no compilation was performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a705cbafac832b9bb385aa486d8441)