### PR TITLE
Add WindowTopmostHelper and enforce HoverFluent topmost on Windows

### DIFF
--- a/IslandCaller.Plugin2/Helpers/WindowTopmostHelper.cs
+++ b/IslandCaller.Plugin2/Helpers/WindowTopmostHelper.cs
@@ -1,0 +1,55 @@
+﻿using Avalonia.Controls;
+using ClassIsland.Shared;
+using Microsoft.Extensions.Logging;
+using System.Runtime.InteropServices;
+
+namespace IslandCaller.Helpers
+{
+    public class WindowTopmostHelper
+    {
+        private readonly ILogger<WindowTopmostHelper> logger = IAppHost.GetService<ILogger<WindowTopmostHelper>>();
+
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern bool SetWindowPos(
+            IntPtr hWnd,
+            IntPtr hWndInsertAfter,
+            int X,
+            int Y,
+            int cx,
+            int cy,
+            uint uFlags);
+
+        private static readonly IntPtr HWND_TOPMOST = new(-1);
+
+        private const uint SWP_NOSIZE = 0x0001;
+        private const uint SWP_NOMOVE = 0x0002;
+        private const uint SWP_NOACTIVATE = 0x0010;
+
+        public void EnsureTopmost(Window window)
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                logger.LogInformation("当前操作系统不是 Windows，跳过置顶调用。");
+                return;
+            }
+
+            var platformHandle = window.TryGetPlatformHandle();
+            if (platformHandle == null)
+            {
+                logger.LogWarning("无法获取窗口句柄，置顶失败。");
+                return;
+            }
+
+            var hwnd = platformHandle.Handle;
+            var success = SetWindowPos(hwnd, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+            if (!success)
+            {
+                var errorCode = Marshal.GetLastWin32Error();
+                logger.LogWarning("SetWindowPos 调用失败，错误码: {ErrorCode}", errorCode);
+                return;
+            }
+
+            logger.LogTrace("已通过 Win32 API 置顶窗口，句柄: {Hwnd}", hwnd);
+        }
+    }
+}

--- a/IslandCaller.Plugin2/Plugin.cs
+++ b/IslandCaller.Plugin2/Plugin.cs
@@ -45,6 +45,7 @@ namespace IslandCaller
             services.AddSingleton<HistoryService>();
             services.AddSingleton<CoreService>();
             services.AddSingleton<WindowDragHelper>();
+            services.AddSingleton<WindowTopmostHelper>();
             services.AddSettingsPage<SettingPage>();
             AppBase.Current.AppStarted += async (_, _) =>
             {

--- a/IslandCaller.Plugin2/Views/HoverFluent.axaml.cs
+++ b/IslandCaller.Plugin2/Views/HoverFluent.axaml.cs
@@ -1,6 +1,7 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Threading;
+using IslandCaller.Helpers;
 using IslandCaller.Services.IslandCallerService;
 using IslandCaller.ViewModels;
 using Microsoft.Extensions.Logging;
@@ -8,10 +9,13 @@ using Microsoft.Extensions.Logging;
 namespace IslandCaller.Views;
 public partial class HoverFluent : Window
 {
-    private HoverFluentViewModel vm {  get; set; }
-    private double scaling {  get; set; }
-    private ILogger<HoverFluent> logger = ClassIsland.Shared.IAppHost.GetService<ILogger<HoverFluent>>();
-    private IslandCallerService IslandCallerService = ClassIsland.Shared.IAppHost.GetService<IslandCallerService>();
+    private HoverFluentViewModel vm { get; set; }
+    private double scaling { get; set; }
+    private readonly ILogger<HoverFluent> logger = ClassIsland.Shared.IAppHost.GetService<ILogger<HoverFluent>>();
+    private readonly IslandCallerService IslandCallerService = ClassIsland.Shared.IAppHost.GetService<IslandCallerService>();
+    private readonly WindowTopmostHelper windowTopmostHelper = ClassIsland.Shared.IAppHost.GetService<WindowTopmostHelper>();
+    private CancellationTokenSource? topmostCts;
+
     public HoverFluent()
     {
         InitializeComponent();
@@ -20,43 +24,83 @@ public partial class HoverFluent : Window
     protected override void OnOpened(EventArgs e)
     {
         base.OnOpened(e);
-        vm = this.DataContext as HoverFluentViewModel;
-        scaling = this.RenderScaling;
-        this.Position = new PixelPoint((int)Math.Round(vm.PositionX * scaling), (int)Math.Round(vm.PositionY * scaling));
+        vm = DataContext as HoverFluentViewModel;
+        scaling = RenderScaling;
+        Position = new PixelPoint((int)Math.Round(vm.PositionX * scaling), (int)Math.Round(vm.PositionY * scaling));
         PositionChanged += OnPositionChanged;
+        Activated += OnWindowLayerChanged;
+        Deactivated += OnWindowLayerChanged;
         logger.LogDebug($"HoverFluent 坐标: PositionX={(int)Math.Round(vm.PositionX * scaling)}, PositionY={(int)Math.Round(vm.PositionY * scaling)}");
         logger.LogInformation("HoverFluent 悬浮窗初始化成功");
 
+        StartTopmostLoop();
+        ApplyTopmost("窗口打开");
+    }
+
+    protected override void OnClosed(EventArgs e)
+    {
+        PositionChanged -= OnPositionChanged;
+        Activated -= OnWindowLayerChanged;
+        Deactivated -= OnWindowLayerChanged;
+        topmostCts?.Cancel();
+        topmostCts?.Dispose();
+        topmostCts = null;
+        base.OnClosed(e);
+    }
+
+    private void StartTopmostLoop()
+    {
+        topmostCts?.Cancel();
+        topmostCts?.Dispose();
+        topmostCts = new CancellationTokenSource();
+        var token = topmostCts.Token;
+
         Task.Run(async () =>
         {
-            logger.LogInformation("HoverFluent 置顶任务启动");
-            while (true)
+            logger.LogInformation("HoverFluent 置顶任务启动，间隔: 3000ms");
+            while (!token.IsCancellationRequested)
             {
-                await Task.Delay(5000);
-                Dispatcher.UIThread.Invoke(() =>
+                try
                 {
-                    this.Topmost= true;
-                    this.Focusable = false;
-                });
+                    await Task.Delay(3000, token);
+                }
+                catch (TaskCanceledException)
+                {
+                    break;
+                }
+
+                if (token.IsCancellationRequested) break;
+
+                await Dispatcher.UIThread.InvokeAsync(() => ApplyTopmost("定时器触发"));
             }
-            ;
-        });
+            logger.LogInformation("HoverFluent 置顶任务结束");
+        }, token);
+    }
+
+    private void OnWindowLayerChanged(object? sender, EventArgs e)
+    {
+        ApplyTopmost("窗口层级变化");
+    }
+
+    private void ApplyTopmost(string reason)
+    {
+        windowTopmostHelper.EnsureTopmost(this);
+        Focusable = false;
+        logger.LogTrace("执行窗口置顶，触发原因: {Reason}", reason);
     }
 
     private void OnPositionChanged(object? sender, PixelPointEventArgs e)
     {
         var screen = Screens.ScreenFromWindow(this)?.Bounds ?? Screens.Primary.Bounds;
-        scaling = this.RenderScaling;
+        scaling = RenderScaling;
         var logger = ClassIsland.Shared.IAppHost.GetService<ILogger<HoverFluent>>();
         logger.LogDebug($"窗口位置改变: X={Position.X}, Y={Position.Y}");
 
-        // 当前窗口位置和大小
         int x = Position.X;
         int y = Position.Y;
         int w = (int)Width;
         int h = (int)Height;
 
-        // 修正坐标，保证窗口完全在屏幕内
         if (x < screen.X) x = screen.X;
         if (y < screen.Y) y = screen.Y;
         if (x + w > screen.X + screen.Width)
@@ -70,16 +114,12 @@ public partial class HoverFluent : Window
             logger.LogInformation("调整Y坐标以适应屏幕");
         }
 
-        // 如果有调整，更新位置
         if (x != Position.X || y != Position.Y)
         {
             Position = new PixelPoint(x, y);
         }
 
-        vm.PositionX = x / scaling; 
+        vm.PositionX = x / scaling;
         vm.PositionY = y / scaling;
     }
-
- 
-
 }


### PR DESCRIPTION
### Motivation
- Ensure the `HoverFluent` floating window stays on top on Windows by calling the native Win32 `SetWindowPos` when needed and reacting to window layer changes.

### Description
- Add `WindowTopmostHelper` with a P/Invoke `SetWindowPos` wrapper that checks OS and logs errors and results in `WindowTopmostHelper.cs`.
- Register the helper in DI with `services.AddSingleton<WindowTopmostHelper>();`.
- Update `HoverFluent` to use a `WindowTopmostHelper` instance, make logger and service fields `readonly`, and subscribe to `Activated`/`Deactivated` events.
- Implement a cancellable background loop that periodically reapplies topmost (every 3000ms) on the UI thread and call `EnsureTopmost` on window open, on layer changes, and from the timer; cancel the loop on close.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad4418b558832b94c93796d42ff5bb)