### PR TITLE
feat(plugin2): migrate legacy install when default profile CSV is detected

### DIFF
--- a/IslandCaller.Plugin2/Models/Settings.cs
+++ b/IslandCaller.Plugin2/Models/Settings.cs
@@ -9,6 +9,56 @@ namespace IslandCaller.Models
         public static SettingsModel Instance { get; } = new SettingsModel();
         public ProfileService ProfileService { get; } = profileService;
 
+        private static string GetAppDataRootPath()
+        {
+            return Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                "IslandCaller"
+            );
+        }
+
+        private static bool HasLegacyDefaultProfileFile()
+        {
+            string profilePath = Path.Combine(GetAppDataRootPath(), "Profile");
+            return File.Exists(Path.Combine(profilePath, "Default.csv")) ||
+                   File.Exists(Path.Combine(profilePath, "default.csv"));
+        }
+
+        private static void CleanupLegacyInstall()
+        {
+            string appDataRootPath = GetAppDataRootPath();
+
+            if (Directory.Exists(appDataRootPath))
+            {
+                Directory.Delete(appDataRootPath, recursive: true);
+            }
+
+            Registry.CurrentUser.DeleteSubKeyTree(@"Software\IslandCaller", throwOnMissingSubKey: false);
+        }
+
+        private void InitializeNewInstall()
+        {
+            RegistryKey IsC_RootKey = Registry.CurrentUser.CreateSubKey(@"Software\IslandCaller", writable: true);
+            RegistryKey IsC_GeneralKey = IsC_RootKey?.CreateSubKey("General", writable: true);
+            RegistryKey IsC_ProfileKey = IsC_RootKey?.CreateSubKey("Profile", writable: true);
+            RegistryKey IsC_HoverKey = IsC_RootKey?.CreateSubKey("Hover", writable: true);
+            RegistryKey IsC_HoverKey_Position = IsC_HoverKey?.CreateSubKey("Position", writable: true);
+
+            IsC_GeneralKey?.SetValue("BreakDisable", Instance.General.BreakDisable);
+            IsC_ProfileKey?.SetValue("ProfileNum", Instance.Profile.ProfileNum);
+            IsC_ProfileKey?.SetValue("DefaultProfileName", Instance.Profile.DefaultProfile.ToString());
+            IsC_ProfileKey?.SetValue("IsPreferProfile", Instance.Profile.IsPreferProfile);
+            IsC_ProfileKey?.SetValue("ProfileList", JsonSerializer.Serialize(Instance.Profile.ProfileList));
+            IsC_ProfileKey?.SetValue("PreferProfile", JsonSerializer.Serialize(Instance.Profile.ProfilePrefer));
+            IsC_HoverKey?.SetValue("IsEnable", Instance.Hover.IsEnable);
+            IsC_HoverKey?.SetValue("ScalingFactor", Instance.Hover.ScalingFactor);
+            IsC_HoverKey_Position?.SetValue("X", Instance.Hover.Position.X);
+            IsC_HoverKey_Position?.SetValue("Y", Instance.Hover.Position.Y);
+
+            ProfileService.CreateDemoProfile(Instance.Profile.DefaultProfile);
+            ClassIsland.Core.Controls.CommonTaskDialogs.ShowDialog("Welcome", "欢迎使用IslandCaller2.0");
+        }
+
         public void Load()
         {
             RegistryKey IsC_RootKey = Registry.CurrentUser.OpenSubKey(@"Software\IslandCaller", writable: true);
@@ -19,28 +69,18 @@ namespace IslandCaller.Models
 
             if (IsC_RootKey == null)
             {
-                IsC_RootKey = Registry.CurrentUser.CreateSubKey(@"Software\IslandCaller", writable: true);
-                IsC_GeneralKey = IsC_RootKey?.CreateSubKey("General", writable: true);
-                IsC_ProfileKey = IsC_RootKey?.CreateSubKey("Profile", writable: true);
-                IsC_HoverKey = IsC_RootKey?.CreateSubKey("Hover", writable: true);
-                IsC_HoverKey_Position = IsC_HoverKey?.CreateSubKey("Position", writable: true);
-
-                IsC_GeneralKey?.SetValue("BreakDisable", Instance.General.BreakDisable);
-                IsC_ProfileKey?.SetValue("ProfileNum", Instance.Profile.ProfileNum);
-                IsC_ProfileKey?.SetValue("DefaultProfileName", Instance.Profile.DefaultProfile.ToString());
-                IsC_ProfileKey?.SetValue("IsPreferProfile", Instance.Profile.IsPreferProfile);
-                IsC_ProfileKey?.SetValue("ProfileList", JsonSerializer.Serialize(Instance.Profile.ProfileList));
-                IsC_ProfileKey?.SetValue("PreferProfile", JsonSerializer.Serialize(Instance.Profile.ProfilePrefer));
-                IsC_HoverKey?.SetValue("IsEnable", Instance.Hover.IsEnable);
-                IsC_HoverKey?.SetValue("ScalingFactor", Instance.Hover.ScalingFactor);
-                IsC_HoverKey_Position?.SetValue("X", Instance.Hover.Position.X);
-                IsC_HoverKey_Position?.SetValue("Y", Instance.Hover.Position.Y);
-
-                ProfileService.CreateDemoProfile(Instance.Profile.DefaultProfile);
-                ClassIsland.Core.Controls.CommonTaskDialogs.ShowDialog("Welcome", "欢迎使用IslandCaller2.0");
+                InitializeNewInstall();
             }
             else
             {
+                if (HasLegacyDefaultProfileFile())
+                {
+                    CleanupLegacyInstall();
+                    InitializeNewInstall();
+                    SettingsBinder.Bind(Instance, Save);
+                    return;
+                }
+
                 IsC_GeneralKey = IsC_RootKey?.OpenSubKey("General", writable: true);
                 IsC_ProfileKey = IsC_RootKey?.OpenSubKey("Profile", writable: true);
                 IsC_HoverKey = IsC_RootKey?.OpenSubKey("Hover", writable: true);


### PR DESCRIPTION
### Motivation
- Support migration from older installs that left a `Default.csv`/`default.csv` in `AppData/Roaming/IslandCaller/Profile` even when the registry key `HKCU\Software\IslandCaller` already exists.

### Description
- Added helper `GetAppDataRootPath()` and detector `HasLegacyDefaultProfileFile()` to locate legacy `Default.csv` files under `AppData/Roaming/IslandCaller/Profile`.
- Added `CleanupLegacyInstall()` to remove the legacy AppData root and delete the `HKCU\Software\IslandCaller` registry tree.
- Extracted the existing new-install setup into `InitializeNewInstall()` (creates registry defaults, demo profile and welcome dialog) and invoked it from `Load()` for both first-time installs and after legacy cleanup.
- Updated `Settings.Load()` to run cleanup+reinitialization when a legacy default CSV is found and to reuse `InitializeNewInstall()` when the registry key is missing.

### Testing
- Ran `dotnet build IslandCaller.Plugin2/IslandCaller.Plugin2.csproj` to validate the change, but the build could not be executed in this environment because `dotnet` is not available (`command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad53801024832bbe4d750001851db4)